### PR TITLE
Node Module "Sass Media Mixins" caused problems for Team City

### DIFF
--- a/src/css/_index.scss
+++ b/src/css/_index.scss
@@ -1,4 +1,4 @@
-@import '../../node_modules/sass-media-mixins/index';
+@import 'media-mixins/index';
 @import 'settings';
 @import 'mixins';
 @import 'fonts';

--- a/src/css/media-mixins/_settings.scss
+++ b/src/css/media-mixins/_settings.scss
@@ -1,0 +1,13 @@
+// Media query breakpoints
+
+$media-small-start:    0 !default;
+$media-medium-start:   640px !default;
+$media-large-start:    1280px !default;
+
+// Media queries
+
+$media-query-small:             media-query-width($media-small-start, $media-medium-start - 1px) !default;
+$media-query-small-and-medium:  media-query-width($media-small-start, $media-large-start - 1px) !default;
+$media-query-medium:            media-query-width($media-medium-start, $media-large-start - 1px) !default;
+$media-query-medium-and-large:  media-query-width($media-medium-start) !default;
+$media-query-large:             media-query-width($media-large-start) !default;

--- a/src/css/media-mixins/functions/_media-query-width.scss
+++ b/src/css/media-mixins/functions/_media-query-width.scss
@@ -1,0 +1,7 @@
+@function media-query-width($min-width, $max-width: null){
+  $str: '(min-width: #{$min-width})';
+  @if $max-width {
+    $str: $str +  ' and (max-width: #{$max-width})';
+  }
+  @return $str;
+}

--- a/src/css/media-mixins/index.scss
+++ b/src/css/media-mixins/index.scss
@@ -1,0 +1,3 @@
+@import "functions/media-query-width";
+@import "settings";
+@import "mixins/media";

--- a/src/css/media-mixins/mixins/_media.scss
+++ b/src/css/media-mixins/mixins/_media.scss
@@ -1,0 +1,19 @@
+@mixin media-small {
+  @media #{$media-query-small} { @content; }
+}
+
+@mixin media-medium {
+  @media #{$media-query-medium} { @content; }
+}
+
+@mixin media-small-and-medium {
+  @media #{$media-query-small-and-medium} { @content; }
+}
+
+@mixin media-medium-and-large {
+  @media #{$media-query-medium-and-large} { @content; }
+}
+
+@mixin media-large {
+  @media #{$media-query-large} { @content; }
+}

--- a/src/css/media-mixins/package.json
+++ b/src/css/media-mixins/package.json
@@ -1,0 +1,79 @@
+{
+  "_args": [
+    [
+      {
+        "raw": "sass-media-mixins@^1.0.0",
+        "scope": null,
+        "escapedName": "sass-media-mixins",
+        "name": "sass-media-mixins",
+        "rawSpec": "^1.0.0",
+        "spec": ">=1.0.0 <2.0.0",
+        "type": "range"
+      },
+      "D:\\projects\\product-filter"
+    ]
+  ],
+  "_from": "sass-media-mixins@>=1.0.0 <2.0.0",
+  "_id": "sass-media-mixins@1.0.0",
+  "_inCache": true,
+  "_installable": true,
+  "_location": "/sass-media-mixins",
+  "_nodeVersion": "5.5.0",
+  "_npmOperationalInternal": {
+    "host": "packages-5-east.internal.npmjs.com",
+    "tmp": "tmp/sass-media-mixins-1.0.0.tgz_1456433257907_0.7730375791434199"
+  },
+  "_npmUser": {
+    "name": "hkvalvik",
+    "email": "hkvalvik@gmail.com"
+  },
+  "_npmVersion": "3.3.12",
+  "_phantomChildren": {},
+  "_requested": {
+    "raw": "sass-media-mixins@^1.0.0",
+    "scope": null,
+    "escapedName": "sass-media-mixins",
+    "name": "sass-media-mixins",
+    "rawSpec": "^1.0.0",
+    "spec": ">=1.0.0 <2.0.0",
+    "type": "range"
+  },
+  "_requiredBy": [
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/sass-media-mixins/-/sass-media-mixins-1.0.0.tgz",
+  "_shasum": "99e91eae31ed1993d02855dff5ec222445486868",
+  "_shrinkwrap": null,
+  "_spec": "sass-media-mixins@^1.0.0",
+  "_where": "D:\\projects\\product-filter",
+  "author": "",
+  "bugs": {
+    "url": "https://github.com/hkvalvik/sass-media-mixins/issues"
+  },
+  "dependencies": {},
+  "description": "## Usage",
+  "devDependencies": {},
+  "directories": {},
+  "dist": {
+    "shasum": "99e91eae31ed1993d02855dff5ec222445486868",
+    "tarball": "https://registry.npmjs.org/sass-media-mixins/-/sass-media-mixins-1.0.0.tgz"
+  },
+  "gitHead": "094e4f17325929bdf5db21b4e06d653d8b824e91",
+  "homepage": "https://github.com/hkvalvik/sass-media-mixins#readme",
+  "license": "MIT",
+  "maintainers": [
+    {
+      "name": "hkvalvik",
+      "email": "hkvalvik@gmail.com"
+    }
+  ],
+  "name": "sass-media-mixins",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hkvalvik/sass-media-mixins.git"
+  },
+  "scripts": {},
+  "version": "1.0.0"
+}

--- a/src/css/media-mixins/readme.md
+++ b/src/css/media-mixins/readme.md
@@ -1,0 +1,23 @@
+# Sass media query mixins
+
+## Usage
+
+    // Media query breakpoints
+
+    $media-small-start: 0;
+    $media-medium-start: 640px;
+    $media-large-start: 1280px;
+
+    // Import
+
+    @import "node_modules/sass-media-mixins/index";
+
+    // Media query mixins
+
+    .my-selector {
+      @include media-small {}
+      @include media-medium {}
+      @include media-large {}
+      @include media-small-and-medium {}
+      @include media-medium-and-large {}
+    }


### PR DESCRIPTION
Copying all the required SASS files out of the module and into a local folder where it can be imported normally should solve this problem.

The issue: SASS @import was failing unless user navigated to product-filter/node_modules and ran NPM install - otherwise the files sass-media-mixins tries to import wo't be there.

This is easicly circumvented locally, bet when Team City should do the gulp part of the build too it fails, because the files are not there.

sass-media-mixins seems to be a stable package, so moving the files to swithing the product-filter/src/css folder should not pose any technical difficulties, but possibly licence/rights issues maybe - guessing not, though.